### PR TITLE
Fix of parameters sorting

### DIFF
--- a/ngx_http_sorted_querystring_module.c
+++ b/ngx_http_sorted_querystring_module.c
@@ -271,6 +271,22 @@ ngx_http_sorted_querystring_args_variable(ngx_http_request_t *r, ngx_http_variab
     return NGX_OK;
 }
 
+static ngx_int_t
+ngx_str_compare(const ngx_str_t *one, const ngx_str_t *two)
+{
+    ngx_int_t rc;
+
+    rc = ngx_strncmp(one->data, two->data, ngx_min(one->len, two->len));
+    if (rc == 0) {
+        if (one->len < two->len) {
+            rc = -1;
+        } else if (one->len > two->len) {
+            rc = 1;
+        }
+    }
+
+    return rc;
+}
 
 ngx_int_t
 ngx_http_sorted_querystring_cmp_parameters(const ngx_queue_t *one, const ngx_queue_t *two)
@@ -281,12 +297,9 @@ ngx_http_sorted_querystring_cmp_parameters(const ngx_queue_t *one, const ngx_que
     first  = ngx_queue_data(one, ngx_http_sorted_querystring_parameter_t, queue);
     second = ngx_queue_data(two, ngx_http_sorted_querystring_parameter_t, queue);
 
-    rc = ngx_strncasecmp(first->key.data, second->key.data, ngx_min(first->key.len, second->key.len));
+    rc = ngx_str_compare(&first->key, &second->key);
     if (rc == 0) {
-        rc = ngx_strncasecmp(first->complete.data, second->complete.data, ngx_min(first->complete.len, second->complete.len));
-        if (rc == 0) {
-            rc = -1;
-        }
+        rc = ngx_str_compare(&first->complete, &second->complete);
     }
 
     return rc;


### PR DESCRIPTION
The following issues have been fixed
1. wrong result of comparison due 'rc = -1;' after equality `complete` on min len of two, for example, key=value&key=value1 will lead to key=value1&key=value
2. RFC 3986 says params are case-sensitive, but ngx_http_sorted_querystring_cmp_parameters uses ngx_strncasecmp
3. the first if compare only min len bytes of keys, so the names are not sorted lexicographically for certain cases, for example key=value, key1=value1, coz '1' < '='